### PR TITLE
Remove XForms documentation (part of php/doc-en#3579)

### DIFF
--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -446,13 +446,6 @@ Ciao Joe. La tua età è di 22 anni.
     se la provenienza dei dati richiesti non ci interessa. Questa variabile 
     contiene un misto di dati GET, POST e COOKIE.
    </para>
-   <para>
-    Si può anche trattare con gli input XForms input in PHP, anche se vi troverete
-    a vostro agio con i form HTML ben supportati per parecchio tempo.
-    Nonostante lavorare con XForms non sia per principianti, si potrebbe essere interessati
-    a loro. Abbiamo anche una <link linkend="features.xforms">breve introduzione
-    per gestire i dati ricevuti da XForms</link> nella nostra sezione features. 
-   </para>
   </section>
   
   <section xml:id="tutorial.oldcode">


### PR DESCRIPTION
Removes the translation in advance of it being removed entirely.