### PR TITLE
Modify the sample code for set_error_handler

### DIFF
--- a/reference/errorfunc/functions/set-error-handler.xml
+++ b/reference/errorfunc/functions/set-error-handler.xml
@@ -214,7 +214,7 @@ function myErrorHandler($errno, $errstr, $errfile, $errline)
     if (!(error_reporting() & $errno)) {
         // Questo codice di errore non è incluso in error_reporting, quindi lascia che ricada
         // nel gestore degli errori PHP standard
-        return;
+        return false;
     }
 
     // potrebbe essere necessario effettuare l'escape di $errstr:


### PR DESCRIPTION
https://www.php.net/manual/it/function.set-error-handler.php
Within the sample code on this page, you must return false to hand off processing to PHP's standard error handler.