### PR TITLE
Update intro.xml

### DIFF
--- a/chapters/intro.xml
+++ b/chapters/intro.xml
@@ -52,7 +52,7 @@
     che il codice viene eseguito nel server, generando HTML che sarà dopo
     inviato al client. Il client dovrebbe ricevere
     i risultati dell'esecuzione dello script, ma non potrà
-    conoscere qual'è il codice eseguito. Potete persino configurare il vostro web server per processare
+    conoscere qual è il codice eseguito. Potete persino configurare il vostro web server per processare
     tutte i vostri file HTML con PHP ed allora non ci sarebbe realmente alcun modo per gli
     utenti di sapere cosa avete sul vostro server. 
    </para>


### PR DESCRIPTION
Piccola correzione di qual'è in "qual è". In italiano non è previsto l'uso dell'apostrofo in questo caso.