### PR TITLE
Update reference/zlib/functions/gzuncompress.xml

### DIFF
--- a/reference/zlib/functions/gzuncompress.xml
+++ b/reference/zlib/functions/gzuncompress.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 02ba67b51f2bde571b6ce07026e935f4e81019af Maintainer: vpinti Status: ready -->
+<!-- CREDITS: riccardoscotti -->
 <refentry xml:id="function.gzuncompress" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gzuncompress</refname>

--- a/reference/zlib/functions/gzuncompress.xml
+++ b/reference/zlib/functions/gzuncompress.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: riccardoscotti Status: ready -->
+<!-- EN-Revision: 02ba67b51f2bde571b6ce07026e935f4e81019af Maintainer: vpinti Status: ready -->
 <refentry xml:id="function.gzuncompress" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gzuncompress</refname>
@@ -8,9 +8,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>gzuncompress</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>gzuncompress</methodname>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>max_length</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>   
    Questa funzione decomprime una stringa compressa.  
@@ -29,7 +29,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>length</parameter></term>
+     <term><parameter>max_length</parameter></term>
      <listitem>
       <para>
        La lunghezza massima del dato da decomprimere.
@@ -47,7 +47,7 @@
   <para>
    La funzione ritornerà un errore se il dato decompresso è più di
    32768 volte la lunghezza dell'input compresso <parameter>data</parameter> 
-   oppure se è maggiore del parametro opzionale <parameter>length</parameter>.
+   oppure se è maggiore del parametro opzionale <parameter>max_length</parameter>.
   </para>
  </refsect1>
  <refsect1 role="examples">


### PR DESCRIPTION
Aligns the Italian gzuncompress.xml with the current English source.
Renames the length parameter to max_length and changes the return type from string to string|false. 
EN-Revision hash updated.

Closes #153