### PR TITLE
Translate sockets extension to Italian (missing/new pages)

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1450,3 +1450,19 @@ La <type>resource</type> XMLWriter che è stata modificata. Questa risorsa deriv
 </note>
 '>
 
+<!-- sockets extension changelog snippets -->
+<!ENTITY sockets.changelog.socket-param '<row xmlns="http://docbook.org/ns/docbook">
+  <entry>8.0.0</entry>
+  <entry>
+   <parameter>socket</parameter> ora è un&apos;istanza di <classname>Socket</classname>;
+   in precedenza era una <type>resource</type>.
+  </entry>
+ </row>'>
+<!ENTITY sockets.changelog.address-param '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.0.0</entry>
+ <entry>
+  <parameter>address</parameter> ora è un&apos;istanza di <classname>AddressInfo</classname>;
+  in precedenza era una <type>resource</type>.
+ </entry>
+</row>'>
+

--- a/reference/sockets/addressinfo.xml
+++ b/reference/sockets/addressinfo.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: vpinti Status: ready -->
+<reference xml:id="class.addressinfo" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>La classe AddressInfo</title>
+ <titleabbrev>AddressInfo</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ AddressInfo intro -->
+  <section xml:id="addressinfo.intro">
+   &reftitle.intro;
+   <para>
+    Una classe completamente opaca che, a partire da PHP 8.0.0, sostituisce le risorse <literal>AddressInfo</literal>.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="addressinfo.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>final</modifier>
+     <classname>AddressInfo</classname>
+    </ooclass>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+ <!-- &reference.sockets.entities.addressinfo; -->
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/book.xml
+++ b/reference/sockets/book.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 5f8047c12b4078a6f686b2b0589e9284c47bf155 Maintainer: vpinti Status: ready -->
+
+<book xml:id="book.sockets" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="bundled" ?>
+ <title>Sockets</title>
+
+ <!-- {{{ preface -->
+ <preface xml:id="intro.sockets">
+  &reftitle.intro;
+  <para>
+   L'estensione socket implementa un'interfaccia di basso livello alle
+   funzioni di comunicazione tramite socket, basata sui diffusi socket BSD,
+   offrendo la possibilità di operare sia come server sia come client.
+  </para>
+  <para>
+   Per un'interfaccia socket lato client più generica, vedi
+   <function>stream_socket_client</function>,
+   <function>stream_socket_server</function>,
+   <function>fsockopen</function> e
+   <function>pfsockopen</function>.
+  </para>
+  <para>
+   Quando si utilizzano queste funzioni, è importante ricordare che, sebbene
+   molte di esse abbiano nomi identici alle corrispondenti funzioni C, spesso
+   presentano dichiarazioni differenti. Assicurati di leggere le descrizioni
+   per evitare confusione.
+  </para>
+  <para>
+   Chi non ha familiarità con la programmazione dei socket può trovare molto
+   materiale utile nelle apposite pagine man di Unix, e in rete è disponibile
+   un'ampia documentazione tutorial sulla programmazione dei socket in C, gran
+   parte della quale può essere applicata, con lievi modifiche, alla
+   programmazione dei socket in PHP. La <link xlink:href="&url.socket.faq;">Unix Socket
+   FAQ</link> può essere un buon punto di partenza.
+  </para>
+ </preface>
+ <!-- }}} -->
+
+ &reference.sockets.setup;
+ &reference.sockets.constants;
+ &reference.sockets.examples;
+ &reference.sockets.errors;
+ &reference.sockets.reference;
+ &reference.sockets.socket;
+ &reference.sockets.addressinfo;
+</book>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -239,7 +239,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -272,9 +272,9 @@
    </term>
    <listitem>
     <simpara>
-     This constant is only available on platforms that
-     support the <constant>SO_REUSEPORT</constant> socket option: this
-     includes Linux, macOS and *BSD, but does not include Windows.
+     Questa costante è disponibile solo sulle piattaforme che
+     supportano l'opzione socket <constant>SO_REUSEPORT</constant>: questo
+     include Linux, macOS e *BSD, ma non Windows.
     </simpara>
    </listitem>
   </varlistentry>
@@ -428,7 +428,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -450,7 +450,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -461,7 +461,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -472,7 +472,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -483,7 +483,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -494,7 +494,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -505,7 +505,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.1.0
+     Disponibile a partire da PHP 8.1.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -516,7 +516,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.1.0
+     Disponibile a partire da PHP 8.1.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -527,7 +527,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -538,7 +538,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.1.0
+     Disponibile a partire da PHP 8.1.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -549,7 +549,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.1.0
+     Disponibile a partire da PHP 8.1.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -560,7 +560,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.1.0
+     Disponibile a partire da PHP 8.1.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -571,7 +571,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -582,7 +582,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -593,7 +593,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -604,7 +604,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -615,7 +615,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (Linux only)
+     Disponibile a partire da PHP 8.3.0 (solo Linux)
     </simpara>
    </listitem>
   </varlistentry>
@@ -626,7 +626,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (Linux only)
+     Disponibile a partire da PHP 8.3.0 (solo Linux)
     </simpara>
    </listitem>
   </varlistentry>
@@ -637,7 +637,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (Linux only)
+     Disponibile a partire da PHP 8.3.0 (solo Linux)
     </simpara>
    </listitem>
   </varlistentry>
@@ -648,7 +648,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (NetBSD only)
+     Disponibile a partire da PHP 8.3.0 (solo NetBSD)
     </simpara>
    </listitem>
   </varlistentry>
@@ -659,7 +659,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (OpenBSD only)
+     Disponibile a partire da PHP 8.3.0 (solo OpenBSD)
     </simpara>
    </listitem>
   </varlistentry>
@@ -670,7 +670,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (OpenBSD only)
+     Disponibile a partire da PHP 8.3.0 (solo OpenBSD)
     </simpara>
    </listitem>
   </varlistentry>
@@ -681,7 +681,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (FreeBSD only)
+     Disponibile a partire da PHP 8.3.0 (solo FreeBSD)
     </simpara>
    </listitem>
   </varlistentry>
@@ -692,7 +692,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -703,7 +703,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0
+     Disponibile a partire da PHP 8.3.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -714,7 +714,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0
+     Disponibile a partire da PHP 8.3.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -725,7 +725,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0
+     Disponibile a partire da PHP 8.3.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -736,7 +736,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.1.0
+     Disponibile a partire da PHP 8.1.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -747,7 +747,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -758,7 +758,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (Linux only)
+     Disponibile a partire da PHP 8.3.0 (solo Linux)
     </simpara>
    </listitem>
   </varlistentry>
@@ -769,7 +769,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (Linux only)
+     Disponibile a partire da PHP 8.3.0 (solo Linux)
     </simpara>
    </listitem>
   </varlistentry>
@@ -793,7 +793,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (FreeBSD only)
+     Disponibile a partire da PHP 8.3.0 (solo FreeBSD)
     </simpara>
    </listitem>
   </varlistentry>
@@ -804,7 +804,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (Linux only)
+     Disponibile a partire da PHP 8.3.0 (solo Linux)
     </simpara>
    </listitem>
   </varlistentry>
@@ -815,7 +815,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (Linux only)
+     Disponibile a partire da PHP 8.3.0 (solo Linux)
     </simpara>
    </listitem>
   </varlistentry>
@@ -826,7 +826,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (Linux only)
+     Disponibile a partire da PHP 8.3.0 (solo Linux)
     </simpara>
    </listitem>
   </varlistentry>
@@ -837,7 +837,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (Linux only)
+     Disponibile a partire da PHP 8.3.0 (solo Linux)
     </simpara>
    </listitem>
   </varlistentry>
@@ -848,7 +848,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (Linux only)
+     Disponibile a partire da PHP 8.3.0 (solo Linux)
     </simpara>
    </listitem>
   </varlistentry>
@@ -859,7 +859,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (Linux only)
+     Disponibile a partire da PHP 8.3.0 (solo Linux)
     </simpara>
    </listitem>
   </varlistentry>
@@ -870,7 +870,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (Linux only)
+     Disponibile a partire da PHP 8.3.0 (solo Linux)
     </simpara>
    </listitem>
   </varlistentry>
@@ -881,7 +881,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.3.0 (Linux only)
+     Disponibile a partire da PHP 8.3.0 (solo Linux)
     </simpara>
    </listitem>
   </varlistentry>
@@ -2331,7 +2331,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2342,7 +2342,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2353,7 +2353,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2364,7 +2364,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2375,7 +2375,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2386,7 +2386,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2397,7 +2397,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2408,7 +2408,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2419,7 +2419,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2430,7 +2430,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2441,7 +2441,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2452,7 +2452,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2463,7 +2463,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2474,7 +2474,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2485,7 +2485,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2496,7 +2496,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2507,7 +2507,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2518,7 +2518,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2529,7 +2529,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2540,7 +2540,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2551,7 +2551,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -2562,7 +2562,7 @@
    </term>
    <listitem>
     <simpara>
-     Available as of PHP 8.2.0
+     Disponibile a partire da PHP 8.2.0
     </simpara>
    </listitem>
   </varlistentry>
@@ -3131,8 +3131,8 @@
    </term>
    <listitem>
     <simpara>
-     Prevents other sockets from being forcibly bound to the same address and port.
-     Available as of PHP 8.4.0. (Windows only)
+     Impedisce ad altri socket di eseguire forzatamente il bind sullo stesso indirizzo e porta.
+     Disponibile a partire da PHP 8.4.0. (solo Windows)
     </simpara>
    </listitem>
   </varlistentry>
@@ -3143,8 +3143,8 @@
    </term>
    <listitem>
     <simpara>
-     Enable/disable exclusive binding of the socket.
-     Available as of PHP 8.4.0. (Solaris only)
+     Abilita/disabilita il bind esclusivo del socket.
+     Disponibile a partire da PHP 8.4.0. (solo Solaris)
     </simpara>
    </listitem>
   </varlistentry>
@@ -3155,8 +3155,8 @@
    </term>
    <listitem>
     <simpara>
-     Controls generation of SIGPIPE for the socket.
-     Available as of PHP 8.4.0. (macOs and FreeBSD only)
+     Controlla la generazione di SIGPIPE per il socket.
+     Disponibile a partire da PHP 8.4.0. (solo macOS e FreeBSD)
     </simpara>
    </listitem>
   </varlistentry>
@@ -3167,9 +3167,9 @@
    </term>
    <listitem>
     <simpara>
-     Similar to <constant>SO_LINGER</constant> but lingering is in seconds
-     as opposed to time clicks on macOs.
-     Available as of PHP 8.4.0. (macOs only)
+     Simile a <constant>SO_LINGER</constant> ma l'attesa (lingering) è espressa in secondi
+     anziché in tick di tempo su macOS.
+     Disponibile a partire da PHP 8.4.0. (solo macOS)
     </simpara>
    </listitem>
   </varlistentry>
@@ -3180,8 +3180,8 @@
    </term>
    <listitem>
     <simpara>
-     Bind a socket to a specific network interface by its index.
-     Available as of PHP 8.4.0.
+     Esegue il bind di un socket su una specifica interfaccia di rete tramite il suo indice.
+     Disponibile a partire da PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -943,8 +943,8 @@
  </variablelist>
 
  <simpara>
-  The following constants are defined under Windows and UNIX-like platforms.
-  Each constant is only defined if their equal is available on the platform.
+  Le seguenti costanti sono definite sia sotto Windows sia sulle piattaforme di tipo UNIX.
+  Ogni costante è definita solo se il suo equivalente è disponibile sulla piattaforma.
  </simpara>
 
  <variablelist>
@@ -955,7 +955,7 @@
    </term>
    <listitem>
     <simpara>
-     Interrupted system call.
+     Chiamata di sistema interrotta.
     </simpara>
    </listitem>
   </varlistentry>
@@ -966,7 +966,7 @@
    </term>
    <listitem>
     <simpara>
-     Bad file descriptor number.
+     Numero di descrittore di file non valido.
     </simpara>
    </listitem>
   </varlistentry>
@@ -977,7 +977,7 @@
    </term>
    <listitem>
     <simpara>
-     Permission denied.
+     Permesso negato.
     </simpara>
    </listitem>
   </varlistentry>
@@ -988,7 +988,7 @@
    </term>
    <listitem>
     <simpara>
-     Bad address.
+     Indirizzo non valido.
     </simpara>
    </listitem>
   </varlistentry>
@@ -999,7 +999,7 @@
    </term>
    <listitem>
     <simpara>
-     Invalid argument.
+     Argomento non valido.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1010,7 +1010,7 @@
    </term>
    <listitem>
     <simpara>
-     Too many open files.
+     Troppi file aperti.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1021,7 +1021,7 @@
    </term>
    <listitem>
     <simpara>
-     File name too long.
+     Nome del file troppo lungo.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1032,7 +1032,7 @@
    </term>
    <listitem>
     <simpara>
-     Directory not empty.
+     Directory non vuota.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1043,7 +1043,7 @@
    </term>
    <listitem>
     <simpara>
-     Too many symbolic links encountered.
+     Troppi collegamenti simbolici incontrati.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1054,7 +1054,7 @@
    </term>
    <listitem>
     <simpara>
-     Operation would block.
+     L'operazione si bloccherebbe.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1065,7 +1065,7 @@
    </term>
    <listitem>
     <simpara>
-     Object is remote.
+     L'oggetto è remoto.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1076,7 +1076,7 @@
    </term>
    <listitem>
     <simpara>
-     Too many users.
+     Troppi utenti.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1087,7 +1087,7 @@
    </term>
    <listitem>
     <simpara>
-     Socket operation on non-socket.
+     Operazione socket su un elemento che non è un socket.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1098,7 +1098,7 @@
    </term>
    <listitem>
     <simpara>
-     Destination address required.
+     Indirizzo di destinazione richiesto.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1109,7 +1109,7 @@
    </term>
    <listitem>
     <simpara>
-     Message too long.
+     Messaggio troppo lungo.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1120,7 +1120,7 @@
    </term>
    <listitem>
     <simpara>
-     Protocol wrong type for socket.
+     Tipo di protocollo errato per il socket.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1131,7 +1131,7 @@
    </term>
    <listitem>
     <simpara>
-     Protocol not supported.
+     Protocollo non supportato.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1142,7 +1142,7 @@
    </term>
    <listitem>
     <simpara>
-     Socket type not supported.
+     Tipo di socket non supportato.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1153,7 +1153,7 @@
    </term>
    <listitem>
     <simpara>
-     Operation not supported on transport endpoint.
+     Operazione non supportata sull'endpoint di trasporto.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1164,7 +1164,7 @@
    </term>
    <listitem>
     <simpara>
-     Protocol family not supported.
+     Famiglia di protocolli non supportata.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1175,7 +1175,7 @@
    </term>
    <listitem>
     <simpara>
-     Address family not supported by protocol.
+     Famiglia di indirizzi non supportata dal protocollo.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1186,7 +1186,7 @@
    </term>
    <listitem>
     <simpara>
-     Cannot assign requested address.
+     Impossibile assegnare l'indirizzo richiesto.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1197,7 +1197,7 @@
    </term>
    <listitem>
     <simpara>
-     Network is down.
+     La rete non è attiva.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1208,7 +1208,7 @@
    </term>
    <listitem>
     <simpara>
-     Network is unreachable.
+     La rete non è raggiungibile.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1219,7 +1219,7 @@
    </term>
    <listitem>
     <simpara>
-     Network dropped connection because of reset.
+     La rete ha interrotto la connessione a causa di un reset.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1230,7 +1230,7 @@
    </term>
    <listitem>
     <simpara>
-     Software caused connection abort.
+     Il software ha causato l'interruzione della connessione.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1241,7 +1241,7 @@
    </term>
    <listitem>
     <simpara>
-     Connection reset by peer.
+     Connessione azzerata dal peer.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1252,7 +1252,7 @@
    </term>
    <listitem>
     <simpara>
-     No buffer space available.
+     Spazio di buffer non disponibile.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1263,7 +1263,7 @@
    </term>
    <listitem>
     <simpara>
-     Transport endpoint is already connected.
+     L'endpoint di trasporto è già connesso.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1274,7 +1274,7 @@
    </term>
    <listitem>
     <simpara>
-     Transport endpoint is not connected.
+     L'endpoint di trasporto non è connesso.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1285,7 +1285,7 @@
    </term>
    <listitem>
     <simpara>
-     Cannot send after transport endpoint shutdown.
+     Impossibile inviare dopo la chiusura dell'endpoint di trasporto.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1296,7 +1296,7 @@
    </term>
    <listitem>
     <simpara>
-     Connection timed out.
+     Connessione scaduta.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1307,7 +1307,7 @@
    </term>
    <listitem>
     <simpara>
-     Connection refused.
+     Connessione rifiutata.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1318,7 +1318,7 @@
    </term>
    <listitem>
     <simpara>
-     Host is down.
+     L'host non è attivo.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1329,7 +1329,7 @@
    </term>
    <listitem>
     <simpara>
-     No route to host.
+     Nessuna rotta verso l'host.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1340,7 +1340,7 @@
    </term>
    <listitem>
     <simpara>
-     Operation already in progress.
+     Operazione già in corso.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1351,14 +1351,14 @@
    </term>
    <listitem>
     <simpara>
-     Operation now in progress.
+     Operazione ora in corso.
     </simpara>
    </listitem>
   </varlistentry>
  </variablelist>
 
  <simpara>
-  The following constants are only defined under Windows.
+  Le seguenti costanti sono definite solo sotto Windows.
  </simpara>
 
  <variablelist>
@@ -1561,9 +1561,8 @@
  </variablelist>
 
  <simpara>
-  The following constants are only available on UNIX-like
-  platforms. Each constant is only defined if their equal is
-  available on the platform.
+  Le seguenti costanti sono disponibili solo sulle piattaforme di tipo UNIX.
+  Ogni costante è definita solo se il suo equivalente è disponibile sulla piattaforma.
  </simpara>
 
  <variablelist>
@@ -1574,7 +1573,7 @@
    </term>
    <listitem>
     <simpara>
-     Operation not permitted.
+     Operazione non consentita.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1585,7 +1584,7 @@
    </term>
    <listitem>
     <simpara>
-     No such file or directory.
+     File o directory inesistente.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1596,7 +1595,7 @@
    </term>
    <listitem>
     <simpara>
-     I/O error.
+     Errore di I/O.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1607,7 +1606,7 @@
    </term>
    <listitem>
     <simpara>
-     No such device or address.
+     Dispositivo o indirizzo inesistente.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1618,7 +1617,7 @@
    </term>
    <listitem>
     <simpara>
-     Arg list too long.
+     Elenco di argomenti troppo lungo.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1629,7 +1628,7 @@
    </term>
    <listitem>
     <simpara>
-     Try again.
+     Riprovare.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1640,7 +1639,7 @@
    </term>
    <listitem>
     <simpara>
-     Out of memory.
+     Memoria esaurita.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1651,7 +1650,7 @@
    </term>
    <listitem>
     <simpara>
-     Block device required.
+     Richiesto un dispositivo a blocchi.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1662,7 +1661,7 @@
    </term>
    <listitem>
     <simpara>
-     Device or resource busy.
+     Dispositivo o risorsa occupata.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1673,7 +1672,7 @@
    </term>
    <listitem>
     <simpara>
-     File exists.
+     Il file esiste già.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1684,7 +1683,7 @@
    </term>
    <listitem>
     <simpara>
-     Cross-device link.
+     Collegamento tra dispositivi diversi.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1695,7 +1694,7 @@
    </term>
    <listitem>
     <simpara>
-     No such device.
+     Dispositivo inesistente.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1706,7 +1705,7 @@
    </term>
    <listitem>
     <simpara>
-     Not a directory.
+     Non è una directory.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1717,7 +1716,7 @@
    </term>
    <listitem>
     <simpara>
-     Is a directory.
+     È una directory.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1728,7 +1727,7 @@
    </term>
    <listitem>
     <simpara>
-     File table overflow.
+     Overflow della tabella dei file.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1739,7 +1738,7 @@
    </term>
    <listitem>
     <simpara>
-     Not a typewriter.
+     Non è un terminale.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1750,7 +1749,7 @@
    </term>
    <listitem>
     <simpara>
-     No space left on device.
+     Spazio esaurito sul dispositivo.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1761,7 +1760,7 @@
    </term>
    <listitem>
     <simpara>
-     Illegal seek.
+     Operazione di seek non consentita.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1772,7 +1771,7 @@
    </term>
    <listitem>
     <simpara>
-     Read-only file system.
+     File system di sola lettura.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1783,7 +1782,7 @@
    </term>
    <listitem>
     <simpara>
-     Too many links.
+     Troppi collegamenti.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1794,7 +1793,7 @@
    </term>
    <listitem>
     <simpara>
-     Broken pipe.
+     Pipe interrotta.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1806,7 +1805,7 @@
    </term>
    <listitem>
     <simpara>
-     No record locks available.
+     Nessun blocco di record disponibile.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1817,7 +1816,7 @@
    </term>
    <listitem>
     <simpara>
-     Function not implemented.
+     Funzione non implementata.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1831,7 +1830,7 @@
    </term>
    <listitem>
     <simpara>
-     No message of desired type.
+     Nessun messaggio del tipo desiderato.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1842,7 +1841,7 @@
    </term>
    <listitem>
     <simpara>
-     Identifier removed.
+     Identificatore rimosso.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1853,7 +1852,7 @@
    </term>
    <listitem>
     <simpara>
-     Channel number out of range.
+     Numero di canale fuori intervallo.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1864,7 +1863,7 @@
    </term>
    <listitem>
     <simpara>
-     Level 2 not synchronized.
+     Livello 2 non sincronizzato.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1875,7 +1874,7 @@
    </term>
    <listitem>
     <simpara>
-     Level 3 halted.
+     Livello 3 arrestato.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1886,7 +1885,7 @@
    </term>
    <listitem>
     <simpara>
-     Level 3 reset.
+     Livello 3 azzerato.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1897,7 +1896,7 @@
    </term>
    <listitem>
     <simpara>
-     Link number out of range.
+     Numero di collegamento fuori intervallo.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1908,7 +1907,7 @@
    </term>
    <listitem>
     <simpara>
-     Protocol driver not attached.
+     Driver di protocollo non collegato.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1919,7 +1918,7 @@
    </term>
    <listitem>
     <simpara>
-     No CSI structure available.
+     Nessuna struttura CSI disponibile.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1930,7 +1929,7 @@
    </term>
    <listitem>
     <simpara>
-     Level 2 halted.
+     Livello 2 arrestato.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1941,7 +1940,7 @@
    </term>
    <listitem>
     <simpara>
-     Invalid exchange.
+     Scambio non valido.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1952,7 +1951,7 @@
    </term>
    <listitem>
     <simpara>
-     Invalid request descriptor.
+     Descrittore di richiesta non valido.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1963,7 +1962,7 @@
    </term>
    <listitem>
     <simpara>
-     Exchange full.
+     Scambio pieno.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1974,7 +1973,7 @@
    </term>
    <listitem>
     <simpara>
-     No anode.
+     Nessun anode.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1985,7 +1984,7 @@
    </term>
    <listitem>
     <simpara>
-     Invalid request code.
+     Codice di richiesta non valido.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1996,7 +1995,7 @@
    </term>
    <listitem>
     <simpara>
-     Invalid slot.
+     Slot non valido.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2007,7 +2006,7 @@
    </term>
    <listitem>
     <simpara>
-     Device not a stream.
+     Il dispositivo non è uno stream.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2018,7 +2017,7 @@
    </term>
    <listitem>
     <simpara>
-     No data available.
+     Nessun dato disponibile.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2029,7 +2028,7 @@
    </term>
    <listitem>
     <simpara>
-     Timer expired.
+     Timer scaduto.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2040,7 +2039,7 @@
    </term>
    <listitem>
     <simpara>
-     Out of streams resources.
+     Risorse di stream esaurite.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2051,7 +2050,7 @@
    </term>
    <listitem>
     <simpara>
-     Machine is not on the network.
+     La macchina non è in rete.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2063,7 +2062,7 @@
    </term>
    <listitem>
     <simpara>
-     Link has been severed.
+     Il collegamento è stato interrotto.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2074,7 +2073,7 @@
    </term>
    <listitem>
     <simpara>
-     Advertise error.
+     Errore di advertise.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2085,7 +2084,7 @@
    </term>
    <listitem>
     <simpara>
-     Srmount error.
+     Errore di srmount.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2096,7 +2095,7 @@
    </term>
    <listitem>
     <simpara>
-     Communication error on send.
+     Errore di comunicazione durante l'invio.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2107,7 +2106,7 @@
    </term>
    <listitem>
     <simpara>
-     Protocol error.
+     Errore di protocollo.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2118,7 +2117,7 @@
    </term>
    <listitem>
     <simpara>
-     Multihop attempted.
+     Tentativo di multihop.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2129,7 +2128,7 @@
    </term>
    <listitem>
     <simpara>
-     Not a data message.
+     Non è un messaggio di dati.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2140,7 +2139,7 @@
    </term>
    <listitem>
     <simpara>
-     Name not unique on network.
+     Nome non univoco in rete.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2151,7 +2150,7 @@
    </term>
    <listitem>
     <simpara>
-     File descriptor in bad state.
+     Descrittore di file in uno stato non valido.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2162,7 +2161,7 @@
    </term>
    <listitem>
     <simpara>
-     Remote address changed.
+     Indirizzo remoto cambiato.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2173,7 +2172,7 @@
    </term>
    <listitem>
     <simpara>
-     Interrupted system call should be restarted.
+     La chiamata di sistema interrotta dovrebbe essere riavviata.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2184,7 +2183,7 @@
    </term>
    <listitem>
     <simpara>
-     Streams pipe error.
+     Errore di pipe degli stream.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2200,7 +2199,7 @@
    </term>
    <listitem>
     <simpara>
-     Protocol not available.
+     Protocollo non disponibile.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2216,7 +2215,7 @@
    </term>
    <listitem>
     <simpara>
-     Address already in use.
+     Indirizzo già in uso.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2237,7 +2236,7 @@
    </term>
    <listitem>
     <simpara>
-     Too many references: cannot splice.
+     Troppi riferimenti: impossibile eseguire lo splice.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2254,7 +2253,7 @@
    </term>
    <listitem>
     <simpara>
-     Is a named type file.
+     È un file di tipo denominato.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2265,7 +2264,7 @@
    </term>
    <listitem>
     <simpara>
-     Remote I/O error.
+     Errore di I/O remoto.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2276,7 +2275,7 @@
    </term>
    <listitem>
     <simpara>
-     Quota exceeded.
+     Quota superata.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2287,7 +2286,7 @@
    </term>
    <listitem>
     <simpara>
-     No medium found.
+     Nessun supporto trovato.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2298,7 +2297,7 @@
    </term>
    <listitem>
     <simpara>
-     Wrong medium type.
+     Tipo di supporto errato.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -439,7 +439,7 @@
    </term>
    <listitem>
     <simpara>
-     Used to disable Nagle TCP algorithm.
+     Usata per disabilitare l'algoritmo di Nagle del TCP.
     </simpara>
    </listitem>
   </varlistentry>
@@ -780,9 +780,9 @@
    </term>
    <listitem>
     <simpara>
-     Set the number of SYN retransmits that TCP should send
-     before aborting the attempt to connect.
-     Available as of PHP 8.4.0 (Linux only)
+     Imposta il numero di ritrasmissioni SYN che il TCP deve inviare
+     prima di interrompere il tentativo di connessione.
+     Disponibile a partire da PHP 8.4.0 (solo Linux)
     </simpara>
    </listitem>
   </varlistentry>
@@ -2843,8 +2843,8 @@
    </term>
    <listitem>
     <simpara>
-     Set the port range used for selecting a local port	number.
-     Available as of PHP 8.4.0. (FreeBSD/NetBSD/OpenBSD only)
+     Imposta l'intervallo di porte usato per selezionare un numero di porta locale.
+     Disponibile a partire da PHP 8.4.0. (solo FreeBSD/NetBSD/OpenBSD)
     </simpara>
    </listitem>
   </varlistentry>
@@ -2855,8 +2855,8 @@
    </term>
    <listitem>
     <simpara>
-     Use the default range of port values.
-     Available as of PHP 8.4.0. (FreeBSD/NetBSD/OpenBSD only)
+     Usa l'intervallo predefinito di valori di porta.
+     Disponibile a partire da PHP 8.4.0. (solo FreeBSD/NetBSD/OpenBSD)
     </simpara>
    </listitem>
   </varlistentry>
@@ -2867,8 +2867,8 @@
    </term>
    <listitem>
     <simpara>
-     Use a high	range of port values.
-     Available as of PHP 8.4.0. (FreeBSD/NetBSD/OpenBSD only)
+     Usa un intervallo alto di valori di porta.
+     Disponibile a partire da PHP 8.4.0. (solo FreeBSD/NetBSD/OpenBSD)
     </simpara>
    </listitem>
   </varlistentry>
@@ -2879,8 +2879,8 @@
    </term>
    <listitem>
     <simpara>
-     Use a low range of port values.
-     Available as of PHP 8.4.0. (FreeBSD/NetBSD/OpenBSD only)
+     Usa un intervallo basso di valori di porta.
+     Disponibile a partire da PHP 8.4.0. (solo FreeBSD/NetBSD/OpenBSD)
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -1,0 +1,3210 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: vpinti Status: ready -->
+<appendix xml:id="sockets.constants" xmlns="http://docbook.org/ns/docbook">
+ &reftitle.constants;
+ &extension.constants;
+ <variablelist>
+  <varlistentry xml:id="constant.af-unix">
+   <term>
+    <constant>AF_UNIX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Famiglia di indirizzi socket dei percorsi del filesystem nel dominio Unix.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.af-inet">
+   <term>
+    <constant>AF_INET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Famiglia di indirizzi socket di IPv4 nel dominio Internet.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.af-inet6">
+   <term>
+    <constant>AF_INET6</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Famiglia di indirizzi socket di IPv6 nel dominio Internet. Disponibile solo se compilato con il supporto a IPv6.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.af-divert">
+   <term>
+    <constant>AF_DIVERT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Famiglia di indirizzi socket per l'interfaccia <literal>divert(4)</literal>
+     di FreeBSD, usata per ricevere i pacchetti deviati dal firewall.
+     Disponibile a partire da PHP 8.3.0 (solo FreeBSD).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.af-packet">
+   <term>
+    <constant>AF_PACKET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Famiglia di indirizzi socket per i packet socket di basso livello, usata per
+     inviare e ricevere pacchetti grezzi a livello di driver di dispositivo (livello OSI 2).
+     Disponibile a partire da PHP 8.5.0 (solo Linux).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sock-stream">
+   <term>
+    <constant>SOCK_STREAM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sock-dgram">
+   <term>
+    <constant>SOCK_DGRAM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sock-raw">
+   <term>
+    <constant>SOCK_RAW</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sock-seqpacket">
+   <term>
+    <constant>SOCK_SEQPACKET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sock-rdm">
+   <term>
+    <constant>SOCK_RDM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sock-conn-dgram">
+   <term>
+    <constant>SOCK_CONN_DGRAM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Imposta il socket su datagramma orientato alla connessione.
+     Disponibile a partire da PHP 8.4.0. (solo NetBSD)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sock-dccp">
+   <term>
+    <constant>SOCK_DCCP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Imposta il socket sul protocollo di controllo della congestione per datagrammi (DCCP).
+     Disponibile a partire da PHP 8.4.0. (solo NetBSD)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sock-nonblock">
+   <term>
+    <constant>SOCK_NONBLOCK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Imposta il flag di stato della modalità "nonblocking" del socket.
+     Disponibile a partire da PHP 8.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sock-cloexec">
+   <term>
+    <constant>SOCK_CLOEXEC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Imposta il flag di stato close-on-exec del socket.
+     Disponibile a partire da PHP 8.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.msg-oob">
+   <term>
+    <constant>MSG_OOB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.msg-waitall">
+   <term>
+    <constant>MSG_WAITALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.msg-peek">
+   <term>
+    <constant>MSG_PEEK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.msg-dontroute">
+   <term>
+    <constant>MSG_DONTROUTE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.msg-eor">
+   <term>
+    <constant>MSG_EOR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Not available on Windows platforms.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.msg-eof">
+   <term>
+    <constant>MSG_EOF</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Not available on Windows platforms.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.msg-zerocopy">
+   <term>
+    <constant>MSG_ZEROCOPY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-debug">
+   <term>
+    <constant>SO_DEBUG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-reuseaddr">
+   <term>
+    <constant>SO_REUSEADDR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-reuseport">
+   <term>
+    <constant>SO_REUSEPORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     This constant is only available on platforms that
+     support the <constant>SO_REUSEPORT</constant> socket option: this
+     includes Linux, macOS and *BSD, but does not include Windows.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-keepalive">
+   <term>
+    <constant>SO_KEEPALIVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-dontroute">
+   <term>
+    <constant>SO_DONTROUTE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-linger">
+   <term>
+    <constant>SO_LINGER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-broadcast">
+   <term>
+    <constant>SO_BROADCAST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-oobinline">
+   <term>
+    <constant>SO_OOBINLINE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-sndbuf">
+   <term>
+    <constant>SO_SNDBUF</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-rcvbuf">
+   <term>
+    <constant>SO_RCVBUF</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-sndlowat">
+   <term>
+    <constant>SO_SNDLOWAT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-rcvlowat">
+   <term>
+    <constant>SO_RCVLOWAT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-sndtimeo">
+   <term>
+    <constant>SO_SNDTIMEO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-rcvtimeo">
+   <term>
+    <constant>SO_RCVTIMEO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-type">
+   <term>
+    <constant>SO_TYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-error">
+   <term>
+    <constant>SO_ERROR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-zerocopy">
+   <term>
+    <constant>SO_ZEROCOPY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-nodelay">
+   <term>
+    <constant>TCP_NODELAY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Used to disable Nagle TCP algorithm.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-keepcnt">
+   <term>
+    <constant>TCP_KEEPCNT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-keepidle">
+   <term>
+    <constant>TCP_KEEPIDLE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-keepintvl">
+   <term>
+    <constant>TCP_KEEPINTVL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-keepalive">
+   <term>
+    <constant>TCP_KEEPALIVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-notsent-lowat">
+   <term>
+    <constant>TCP_NOTSENT_LOWAT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-mark">
+   <term>
+    <constant>SO_MARK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.1.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-user-cookie">
+   <term>
+    <constant>SO_USER_COOKIE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.1.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-rtable">
+   <term>
+    <constant>SO_RTABLE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-acceptfilter">
+   <term>
+    <constant>SO_ACCEPTFILTER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.1.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-donttrunc">
+   <term>
+    <constant>SO_DONTTRUNC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.1.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-wantmore">
+   <term>
+    <constant>SO_WANTMORE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.1.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-incoming-cpu">
+   <term>
+    <constant>SO_INCOMING_CPU</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-meminfo">
+   <term>
+    <constant>SO_MEMINFO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-bpf-extensions">
+   <term>
+    <constant>SO_BPF_EXTENSIONS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-setfib">
+   <term>
+    <constant>SO_SETFIB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-attach-reuseport-cbpf">
+   <term>
+    <constant>SO_ATTACH_REUSEPORT_CBPF</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (Linux only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-detach-bpf">
+   <term>
+    <constant>SO_DETACH_BPF</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (Linux only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-detach-filter">
+   <term>
+    <constant>SO_DETACH_FILTER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (Linux only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-rerror">
+   <term>
+    <constant>SO_RERROR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (NetBSD only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-zeroize">
+   <term>
+    <constant>SO_ZEROIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (OpenBSD only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-splice">
+   <term>
+    <constant>SO_SPLICE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (OpenBSD only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-reuseport-lb">
+   <term>
+    <constant>SO_REUSEPORT_LB</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (FreeBSD only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sol-filter">
+   <term>
+    <constant>SOL_FILTER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sol-udplite">
+   <term>
+    <constant>SOL_UDPLITE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.udplite-recv-cscov">
+   <term>
+    <constant>UDPLITE_RECV_CSCOV</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.udplite-send-cscov">
+   <term>
+    <constant>UDPLITE_SEND_CSCOV</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-defer-accept">
+   <term>
+    <constant>TCP_DEFER_ACCEPT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.1.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-congestion">
+   <term>
+    <constant>TCP_CONGESTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-quickack">
+   <term>
+    <constant>TCP_QUICKACK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (Linux only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-repair">
+   <term>
+    <constant>TCP_REPAIR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (Linux only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-syncnt">
+   <term>
+    <constant>TCP_SYNCNT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Set the number of SYN retransmits that TCP should send
+     before aborting the attempt to connect.
+     Available as of PHP 8.4.0 (Linux only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-dontfrag">
+   <term>
+    <constant>IP_DONTFRAG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (FreeBSD only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-mtu-discover">
+   <term>
+    <constant>IP_MTU_DISCOVER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (Linux only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-pmtudisc-do">
+   <term>
+    <constant>IP_PMTUDISC_DO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (Linux only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-pmtudisc-dont">
+   <term>
+    <constant>IP_PMTUDISC_DONT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (Linux only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-pmtudisc-want">
+   <term>
+    <constant>IP_PMTUDISC_WANT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (Linux only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-pmtudisc-probe">
+   <term>
+    <constant>IP_PMTUDISC_PROBE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (Linux only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-pmtudisc-interface">
+   <term>
+    <constant>IP_PMTUDISC_INTERFACE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (Linux only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-pmtudisc-omit">
+   <term>
+    <constant>IP_PMTUDISC_OMIT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (Linux only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-bind-address-no-port">
+   <term>
+    <constant>IP_BIND_ADDRESS_NO_PORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.3.0 (Linux only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sol-socket">
+   <term>
+    <constant>SOL_SOCKET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-normal-read">
+   <term>
+    <constant>PHP_NORMAL_READ</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-binary-read">
+   <term>
+    <constant>PHP_BINARY_READ</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sol-tcp">
+   <term>
+    <constant>SOL_TCP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sol-udp">
+   <term>
+    <constant>SOL_UDP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+
+ <simpara>
+  The following constants are defined under Windows and UNIX-like platforms.
+  Each constant is only defined if their equal is available on the platform.
+ </simpara>
+
+ <variablelist>
+  <varlistentry xml:id="constant.socket-eintr">
+   <term>
+    <constant>SOCKET_EINTR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Interrupted system call.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-ebadf">
+   <term>
+    <constant>SOCKET_EBADF</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Bad file descriptor number.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eacces">
+   <term>
+    <constant>SOCKET_EACCES</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Permission denied.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-efault">
+   <term>
+    <constant>SOCKET_EFAULT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Bad address.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-einval">
+   <term>
+    <constant>SOCKET_EINVAL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Invalid argument.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-emfile">
+   <term>
+    <constant>SOCKET_EMFILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Too many open files.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enametoolong">
+   <term>
+    <constant>SOCKET_ENAMETOOLONG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     File name too long.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enotempty">
+   <term>
+    <constant>SOCKET_ENOTEMPTY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Directory not empty.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eloop">
+   <term>
+    <constant>SOCKET_ELOOP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Too many symbolic links encountered.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-ewouldblock">
+   <term>
+    <constant>SOCKET_EWOULDBLOCK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Operation would block.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eremote">
+   <term>
+    <constant>SOCKET_EREMOTE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Object is remote.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eusers">
+   <term>
+    <constant>SOCKET_EUSERS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Too many users.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enotsock">
+   <term>
+    <constant>SOCKET_ENOTSOCK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Socket operation on non-socket.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-edestaddrreq">
+   <term>
+    <constant>SOCKET_EDESTADDRREQ</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Destination address required.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-emsgsize">
+   <term>
+    <constant>SOCKET_EMSGSIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Message too long.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eprototype">
+   <term>
+    <constant>SOCKET_EPROTOTYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Protocol wrong type for socket.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eprotonosupport">
+   <term>
+    <constant>SOCKET_EPROTONOSUPPORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Protocol not supported.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-esocktnosupport">
+   <term>
+    <constant>SOCKET_ESOCKTNOSUPPORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Socket type not supported.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eopnotsupp">
+   <term>
+    <constant>SOCKET_EOPNOTSUPP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Operation not supported on transport endpoint.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-epfnosupport">
+   <term>
+    <constant>SOCKET_EPFNOSUPPORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Protocol family not supported.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eafnosupport">
+   <term>
+    <constant>SOCKET_EAFNOSUPPORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Address family not supported by protocol.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eaddrnotavail">
+   <term>
+    <constant>SOCKET_EADDRNOTAVAIL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Cannot assign requested address.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enetdown">
+   <term>
+    <constant>SOCKET_ENETDOWN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Network is down.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enetunreach">
+   <term>
+    <constant>SOCKET_ENETUNREACH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Network is unreachable.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enetreset">
+   <term>
+    <constant>SOCKET_ENETRESET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Network dropped connection because of reset.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-econnaborted">
+   <term>
+    <constant>SOCKET_ECONNABORTED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Software caused connection abort.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-econnreset">
+   <term>
+    <constant>SOCKET_ECONNRESET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Connection reset by peer.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enobufs">
+   <term>
+    <constant>SOCKET_ENOBUFS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No buffer space available.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eisconn">
+   <term>
+    <constant>SOCKET_EISCONN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Transport endpoint is already connected.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enotconn">
+   <term>
+    <constant>SOCKET_ENOTCONN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Transport endpoint is not connected.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eshutdown">
+   <term>
+    <constant>SOCKET_ESHUTDOWN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Cannot send after transport endpoint shutdown.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-etimedout">
+   <term>
+    <constant>SOCKET_ETIMEDOUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Connection timed out.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-econnrefused">
+   <term>
+    <constant>SOCKET_ECONNREFUSED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Connection refused.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-ehostdown">
+   <term>
+    <constant>SOCKET_EHOSTDOWN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Host is down.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-ehostunreach">
+   <term>
+    <constant>SOCKET_EHOSTUNREACH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No route to host.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-ealready">
+   <term>
+    <constant>SOCKET_EALREADY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Operation already in progress.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-einprogress">
+   <term>
+    <constant>SOCKET_EINPROGRESS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Operation now in progress.
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+
+ <simpara>
+  The following constants are only defined under Windows.
+ </simpara>
+
+ <variablelist>
+
+
+
+
+
+
+
+  <varlistentry xml:id="constant.socket-enoprotoopt">
+   <term>
+    <constant>SOCKET_ENOPROTOOPT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+
+
+
+
+  <varlistentry xml:id="constant.socket-eaddrinuse">
+   <term>
+    <constant>SOCKET_EADDRINUSE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+
+
+
+
+
+
+
+
+
+  <varlistentry xml:id="constant.socket-etoomyrefs">
+   <term>
+    <constant>SOCKET_ETOOMYREFS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+
+
+
+
+
+
+  <varlistentry xml:id="constant.socket-eproclim">
+   <term>
+    <constant>SOCKET_EPROCLIM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+  <varlistentry xml:id="constant.socket-eduot">
+   <term>
+    <constant>SOCKET_EDUOT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-estale">
+   <term>
+    <constant>SOCKET_ESTALE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+  <varlistentry xml:id="constant.socket-ediscon">
+   <term>
+    <constant>SOCKET_EDISCON</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-sysnotready">
+   <term>
+    <constant>SOCKET_SYSNOTREADY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-vernotsupported">
+   <term>
+    <constant>SOCKET_VERNOTSUPPORTED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-notinitialised">
+   <term>
+    <constant>SOCKET_NOTINITIALISED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-host-not-found">
+   <term>
+    <constant>SOCKET_HOST_NOT_FOUND</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-try-again">
+   <term>
+    <constant>SOCKET_TRY_AGAIN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-no-recovery">
+   <term>
+    <constant>SOCKET_NO_RECOVERY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-no-data">
+   <term>
+    <constant>SOCKET_NO_DATA</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-no-address">
+   <term>
+    <constant>SOCKET_NO_ADDRESS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+
+ <simpara>
+  The following constants are only available on UNIX-like
+  platforms. Each constant is only defined if their equal is
+  available on the platform.
+ </simpara>
+
+ <variablelist>
+  <varlistentry xml:id="constant.socket-eperm">
+   <term>
+    <constant>SOCKET_EPERM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Operation not permitted.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enoent">
+   <term>
+    <constant>SOCKET_ENOENT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No such file or directory.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eio">
+   <term>
+    <constant>SOCKET_EIO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     I/O error.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enxio">
+   <term>
+    <constant>SOCKET_ENXIO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No such device or address.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-e2big">
+   <term>
+    <constant>SOCKET_E2BIG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Arg list too long.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eagain">
+   <term>
+    <constant>SOCKET_EAGAIN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Try again.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enomem">
+   <term>
+    <constant>SOCKET_ENOMEM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Out of memory.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enotblk">
+   <term>
+    <constant>SOCKET_ENOTBLK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Block device required.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-ebusy">
+   <term>
+    <constant>SOCKET_EBUSY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Device or resource busy.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eexist">
+   <term>
+    <constant>SOCKET_EEXIST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     File exists.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-exdev">
+   <term>
+    <constant>SOCKET_EXDEV</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Cross-device link.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enodev">
+   <term>
+    <constant>SOCKET_ENODEV</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No such device.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enotdir">
+   <term>
+    <constant>SOCKET_ENOTDIR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Not a directory.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eisdir">
+   <term>
+    <constant>SOCKET_EISDIR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Is a directory.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enfile">
+   <term>
+    <constant>SOCKET_ENFILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     File table overflow.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enotty">
+   <term>
+    <constant>SOCKET_ENOTTY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Not a typewriter.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enospc">
+   <term>
+    <constant>SOCKET_ENOSPC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No space left on device.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-espipe">
+   <term>
+    <constant>SOCKET_ESPIPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Illegal seek.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-erofs">
+   <term>
+    <constant>SOCKET_EROFS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Read-only file system.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-emlink">
+   <term>
+    <constant>SOCKET_EMLINK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Too many links.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-epipe">
+   <term>
+    <constant>SOCKET_EPIPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Broken pipe.
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+  <varlistentry xml:id="constant.socket-enolck">
+   <term>
+    <constant>SOCKET_ENOLCK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No record locks available.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enosys">
+   <term>
+    <constant>SOCKET_ENOSYS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Function not implemented.
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+
+
+  <varlistentry xml:id="constant.socket-enomsg">
+   <term>
+    <constant>SOCKET_ENOMSG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No message of desired type.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eidrm">
+   <term>
+    <constant>SOCKET_EIDRM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Identifier removed.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-echrng">
+   <term>
+    <constant>SOCKET_ECHRNG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Channel number out of range.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-el2nsync">
+   <term>
+    <constant>SOCKET_EL2NSYNC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Level 2 not synchronized.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-el3hlt">
+   <term>
+    <constant>SOCKET_EL3HLT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Level 3 halted.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-el3rst">
+   <term>
+    <constant>SOCKET_EL3RST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Level 3 reset.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-elnrng">
+   <term>
+    <constant>SOCKET_ELNRNG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Link number out of range.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eunatch">
+   <term>
+    <constant>SOCKET_EUNATCH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Protocol driver not attached.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enocsi">
+   <term>
+    <constant>SOCKET_ENOCSI</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No CSI structure available.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-el2hlt">
+   <term>
+    <constant>SOCKET_EL2HLT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Level 2 halted.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-ebade">
+   <term>
+    <constant>SOCKET_EBADE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Invalid exchange.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-ebadr">
+   <term>
+    <constant>SOCKET_EBADR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Invalid request descriptor.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-exfull">
+   <term>
+    <constant>SOCKET_EXFULL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Exchange full.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enoano">
+   <term>
+    <constant>SOCKET_ENOANO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No anode.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-ebadrqc">
+   <term>
+    <constant>SOCKET_EBADRQC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Invalid request code.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-ebadslt">
+   <term>
+    <constant>SOCKET_EBADSLT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Invalid slot.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enostr">
+   <term>
+    <constant>SOCKET_ENOSTR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Device not a stream.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enodata">
+   <term>
+    <constant>SOCKET_ENODATA</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No data available.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-etime">
+   <term>
+    <constant>SOCKET_ETIME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Timer expired.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enosr">
+   <term>
+    <constant>SOCKET_ENOSR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Out of streams resources.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enonet">
+   <term>
+    <constant>SOCKET_ENONET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Machine is not on the network.
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+  <varlistentry xml:id="constant.socket-enolink">
+   <term>
+    <constant>SOCKET_ENOLINK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Link has been severed.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eadv">
+   <term>
+    <constant>SOCKET_EADV</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Advertise error.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-esrmnt">
+   <term>
+    <constant>SOCKET_ESRMNT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Srmount error.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-ecomm">
+   <term>
+    <constant>SOCKET_ECOMM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Communication error on send.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eproto">
+   <term>
+    <constant>SOCKET_EPROTO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Protocol error.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-emultihop">
+   <term>
+    <constant>SOCKET_EMULTIHOP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Multihop attempted.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-ebadmsg">
+   <term>
+    <constant>SOCKET_EBADMSG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Not a data message.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enotuniq">
+   <term>
+    <constant>SOCKET_ENOTUNIQ</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Name not unique on network.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-ebadfd">
+   <term>
+    <constant>SOCKET_EBADFD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     File descriptor in bad state.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eremchg">
+   <term>
+    <constant>SOCKET_EREMCHG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Remote address changed.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-erestart">
+   <term>
+    <constant>SOCKET_ERESTART</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Interrupted system call should be restarted.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-estrpipe">
+   <term>
+    <constant>SOCKET_ESTRPIPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Streams pipe error.
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+
+
+
+
+  <varlistentry xml:id="constant.socket-eprotoopt">
+   <term>
+    <constant>SOCKET_EPROTOOPT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Protocol not available.
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+
+
+
+
+  <varlistentry xml:id="constant.socket-addrinuse">
+   <term>
+    <constant>SOCKET_ADDRINUSE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Address already in use.
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+
+
+
+
+
+
+
+
+
+  <varlistentry xml:id="constant.socket-etoomanyrefs">
+   <term>
+    <constant>SOCKET_ETOOMANYREFS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Too many references: cannot splice.
+    </simpara>
+   </listitem>
+  </varlistentry>
+
+
+
+
+
+
+  <varlistentry xml:id="constant.socket-eisnam">
+   <term>
+    <constant>SOCKET_EISNAM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Is a named type file.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-eremoteio">
+   <term>
+    <constant>SOCKET_EREMOTEIO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Remote I/O error.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-edquot">
+   <term>
+    <constant>SOCKET_EDQUOT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Quota exceeded.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-enomedium">
+   <term>
+    <constant>SOCKET_ENOMEDIUM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     No medium found.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.socket-emediumtype">
+   <term>
+    <constant>SOCKET_EMEDIUMTYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Wrong medium type.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.scm-rights">
+   <term>
+    <constant>SCM_RIGHTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+      Send or receive a set of  open  file  descriptors  from  another process.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.scm-credentials">
+   <term>
+    <constant>SCM_CREDENTIALS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.scm-creds">
+   <term>
+    <constant>SCM_CREDS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.scm-creds2">
+   <term>
+    <constant>SCM_CREDS2</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.local-creds">
+   <term>
+    <constant>LOCAL_CREDS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.local-creds-persistent">
+   <term>
+    <constant>LOCAL_CREDS_PERSISTENT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-off">
+   <term>
+    <constant>SKF_AD_OFF</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-protocol">
+   <term>
+    <constant>SKF_AD_PROTOCOL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-pkttype">
+   <term>
+    <constant>SKF_AD_PKTTYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-ifindex">
+   <term>
+    <constant>SKF_AD_IFINDEX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-nlattr">
+   <term>
+    <constant>SKF_AD_NLATTR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-nlattr-nest">
+   <term>
+    <constant>SKF_AD_NLATTR_NEST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-mark">
+   <term>
+    <constant>SKF_AD_MARK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-queue">
+   <term>
+    <constant>SKF_AD_QUEUE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-hatype">
+   <term>
+    <constant>SKF_AD_HATYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-rxhash">
+   <term>
+    <constant>SKF_AD_RXHASH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-cpu">
+   <term>
+    <constant>SKF_AD_CPU</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-alu-xor-x">
+   <term>
+    <constant>SKF_AD_ALU_XOR_X</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-vlan-tag">
+   <term>
+    <constant>SKF_AD_VLAN_TAG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-vlan-tag-present">
+   <term>
+    <constant>SKF_AD_VLAN_TAG_PRESENT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-pay-offset">
+   <term>
+    <constant>SKF_AD_PAY_OFFSET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-random">
+   <term>
+    <constant>SKF_AD_RANDOM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-vlan-tpid">
+   <term>
+    <constant>SKF_AD_VLAN_TPID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.skf-ad-max">
+   <term>
+    <constant>SKF_AD_MAX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Available as of PHP 8.2.0
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ai-addrconfig">
+   <term>
+    <constant>AI_ADDRCONFIG</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ai-all">
+   <term>
+    <constant>AI_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ai-canonidn">
+   <term>
+    <constant>AI_CANONIDN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ai-canonname">
+   <term>
+    <constant>AI_CANONNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ai-idn">
+   <term>
+    <constant>AI_IDN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ai-numerichost">
+   <term>
+    <constant>AI_NUMERICHOST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ai-numericserv">
+   <term>
+    <constant>AI_NUMERICSERV</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ai-passive">
+   <term>
+    <constant>AI_PASSIVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ai-v4mapped">
+   <term>
+    <constant>AI_V4MAPPED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.fil-attach">
+   <term>
+    <constant>FIL_ATTACH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.fil-detach">
+   <term>
+    <constant>FIL_DETACH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ipproto-ip">
+   <term>
+    <constant>IPPROTO_IP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ipproto-ipv6">
+   <term>
+    <constant>IPPROTO_IPV6</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ipv6-hoplimit">
+   <term>
+    <constant>IPV6_HOPLIMIT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ipv6-multicast-hops">
+   <term>
+    <constant>IPV6_MULTICAST_HOPS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ipv6-multicast-if">
+   <term>
+    <constant>IPV6_MULTICAST_IF</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ipv6-multicast-loop">
+   <term>
+    <constant>IPV6_MULTICAST_LOOP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ipv6-pktinfo">
+   <term>
+    <constant>IPV6_PKTINFO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ipv6-recvhoplimit">
+   <term>
+    <constant>IPV6_RECVHOPLIMIT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ipv6-recvpktinfo">
+   <term>
+    <constant>IPV6_RECVPKTINFO</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ipv6-recvtclass">
+   <term>
+    <constant>IPV6_RECVTCLASS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ipv6-tclass">
+   <term>
+    <constant>IPV6_TCLASS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ipv6-unicast-hops">
+   <term>
+    <constant>IPV6_UNICAST_HOPS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ipv6-v6only">
+   <term>
+    <constant>IPV6_V6ONLY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-multicast-if">
+   <term>
+    <constant>IP_MULTICAST_IF</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-multicast-loop">
+   <term>
+    <constant>IP_MULTICAST_LOOP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-multicast-ttl">
+   <term>
+    <constant>IP_MULTICAST_TTL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-portrange">
+   <term>
+    <constant>IP_PORTRANGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Set the port range used for selecting a local port	number.
+     Available as of PHP 8.4.0. (FreeBSD/NetBSD/OpenBSD only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-portrange-default">
+   <term>
+    <constant>IP_PORTRANGE_DEFAULT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Use the default range of port values.
+     Available as of PHP 8.4.0. (FreeBSD/NetBSD/OpenBSD only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-portrange-high">
+   <term>
+    <constant>IP_PORTRANGE_HIGH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Use a high	range of port values.
+     Available as of PHP 8.4.0. (FreeBSD/NetBSD/OpenBSD only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-portrange-low">
+   <term>
+    <constant>IP_PORTRANGE_LOW</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Use a low range of port values.
+     Available as of PHP 8.4.0. (FreeBSD/NetBSD/OpenBSD only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.mcast-block-source">
+   <term>
+    <constant>MCAST_BLOCK_SOURCE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.mcast-join-group">
+   <term>
+    <constant>MCAST_JOIN_GROUP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.mcast-join-source-group">
+   <term>
+    <constant>MCAST_JOIN_SOURCE_GROUP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.mcast-leave-group">
+   <term>
+    <constant>MCAST_LEAVE_GROUP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.mcast-leave-source-group">
+   <term>
+    <constant>MCAST_LEAVE_SOURCE_GROUP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.mcast-unblock-source">
+   <term>
+    <constant>MCAST_UNBLOCK_SOURCE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.msg-cmsg-cloexec">
+   <term>
+    <constant>MSG_CMSG_CLOEXEC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.msg-confirm">
+   <term>
+    <constant>MSG_CONFIRM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.msg-ctrunc">
+   <term>
+    <constant>MSG_CTRUNC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.msg-dontwait">
+   <term>
+    <constant>MSG_DONTWAIT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.msg-errqueue">
+   <term>
+    <constant>MSG_ERRQUEUE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.msg-more">
+   <term>
+    <constant>MSG_MORE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.msg-nosignal">
+   <term>
+    <constant>MSG_NOSIGNAL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.msg-trunc">
+   <term>
+    <constant>MSG_TRUNC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.msg-waitforone">
+   <term>
+    <constant>MSG_WAITFORONE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sol-local">
+   <term>
+    <constant>SOL_LOCAL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.somaxconn">
+   <term>
+    <constant>SOMAXCONN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-bindtodevice">
+   <term>
+    <constant>SO_BINDTODEVICE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-family">
+   <term>
+    <constant>SO_FAMILY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-label">
+   <term>
+    <constant>SO_LABEL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-listenqlen">
+   <term>
+    <constant>SO_LISTENQLEN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-listenqlimit">
+   <term>
+    <constant>SO_LISTENQLIMIT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-passcred">
+   <term>
+    <constant>SO_PASSCRED</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-peerlabel">
+   <term>
+    <constant>SO_PEERLABEL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-exclusiveaddruse">
+   <term>
+    <constant>SO_EXCLUSIVEADDRUSE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Prevents other sockets from being forcibly bound to the same address and port.
+     Available as of PHP 8.4.0. (Windows only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-exclbind">
+   <term>
+    <constant>SO_EXCLBIND</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Enable/disable exclusive binding of the socket.
+     Available as of PHP 8.4.0. (Solaris only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-nosigpipe">
+   <term>
+    <constant>SO_NOSIGPIPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Controls generation of SIGPIPE for the socket.
+     Available as of PHP 8.4.0. (macOs and FreeBSD only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-linger-sec">
+   <term>
+    <constant>SO_LINGER_SEC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Similar to <constant>SO_LINGER</constant> but lingering is in seconds
+     as opposed to time clicks on macOs.
+     Available as of PHP 8.4.0. (macOs only)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-bindtoifindex">
+   <term>
+    <constant>SO_BINDTOIFINDEX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Bind a socket to a specific network interface by its index.
+     Available as of PHP 8.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+
+</appendix>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -217,7 +217,7 @@
    </term>
    <listitem>
     <simpara>
-     Not available on Windows platforms.
+     Non disponibile sulle piattaforme Windows.
     </simpara>
    </listitem>
   </varlistentry>
@@ -228,7 +228,7 @@
    </term>
    <listitem>
     <simpara>
-     Not available on Windows platforms.
+     Non disponibile sulle piattaforme Windows.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2309,7 +2309,7 @@
    </term>
    <listitem>
     <simpara>
-      Send or receive a set of  open  file  descriptors  from  another process.
+      Invia o riceve un insieme di descrittori di file aperti da un altro processo.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/sockets/errors.xml
+++ b/reference/sockets/errors.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: f453f7036c74f5f8ce5e15d3d5abbaf8dfd599e2 Maintainer: vpinti Status: ready -->
+<chapter xml:id="sockets.errors" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Errori dei Socket</title>
+ <para>
+  L'estensione socket è stata scritta per fornire un'interfaccia utilizzabile ai
+  potenti socket BSD. È stata posta attenzione affinché le funzioni operino
+  allo stesso modo sulle implementazioni Win32 e Unix. Quasi tutte le funzioni
+  dei socket possono fallire in determinate condizioni e quindi emettere un
+  messaggio <constant>E_WARNING</constant> che descrive l'errore. A volte questo
+  non accade come desiderato dallo sviluppatore. Per esempio la funzione
+  <function>socket_read</function> può emettere improvvisamente un
+  messaggio <constant>E_WARNING</constant> perché la connessione si è interrotta
+  in modo imprevisto. È comune sopprimere l'avviso con
+  l'operatore <literal>@</literal> e intercettare il codice di errore all'interno
+  dell'applicazione con la funzione <function>socket_last_error</function>. È
+  possibile richiamare la funzione <function>socket_strerror</function> con questo codice
+  di errore per ottenere una stringa che descrive l'errore. Per maggiori informazioni
+  si vedano le loro descrizioni.
+ </para>
+ <note>
+  <para>
+   I messaggi <constant>E_WARNING</constant> generati dall'estensione
+   socket sono in inglese, sebbene il messaggio di errore ottenuto appaia
+   a seconda del locale corrente (<constant>LC_MESSAGES</constant>):
+   <screen>
+<![CDATA[
+Warning - socket_bind() unable to bind address [98]: Die Adresse wird bereits verwendet
+]]>
+   </screen>
+  </para>
+ </note>
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/examples.xml
+++ b/reference/sockets/examples.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: af4410a7e15898c3dbe83d6ea38246745ed9c6fb Maintainer: vpinti Status: ready -->
+
+<chapter xml:id="sockets.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ &reftitle.examples;
+ <para>
+  <example>
+   <title>Esempio di socket: semplice server TCP/IP</title>
+   <para>
+    Questo esempio mostra un semplice server "talkback". Modifica le
+    variabili <varname>address</varname> e <varname>port</varname>
+    per adattarle alla tua configurazione ed eseguilo. Puoi quindi
+    connetterti al server con un comando simile a: <command>telnet 192.168.1.53
+    10000</command> (dove indirizzo e porta corrispondono alla tua
+    configurazione). Tutto ciò che digiti verrà quindi mostrato in output
+    sul lato server e rinviato a te. Per disconnetterti, digita 'quit'.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+#!/usr/local/bin/php -q
+<?php
+error_reporting(E_ALL);
+
+/* Permette allo script di restare in attesa di connessioni. */
+set_time_limit(0);
+
+/* Attiva lo svuotamento implicito dell'output, così vediamo ciò che
+ * riceviamo man mano che arriva. */
+ob_implicit_flush();
+
+$address = '192.168.1.53';
+$port = 10000;
+
+if (($sock = socket_create(AF_INET, SOCK_STREAM, SOL_TCP)) === false) {
+    echo "socket_create() fallita: motivo: " . socket_strerror(socket_last_error()) . "\n";
+}
+
+if (socket_bind($sock, $address, $port) === false) {
+    echo "socket_bind() fallita: motivo: " . socket_strerror(socket_last_error($sock)) . "\n";
+}
+
+if (socket_listen($sock, 5) === false) {
+    echo "socket_listen() fallita: motivo: " . socket_strerror(socket_last_error($sock)) . "\n";
+}
+
+do {
+    if (($msgsock = socket_accept($sock)) === false) {
+        echo "socket_accept() fallita: motivo: " . socket_strerror(socket_last_error($sock)) . "\n";
+        break;
+    }
+    /* Invia le istruzioni. */
+    $msg = "\nBenvenuto nel server di prova di PHP. \n" .
+        "Per uscire, digita 'quit'. Per arrestare il server digita 'shutdown'.\n";
+    socket_write($msgsock, $msg, strlen($msg));
+
+    do {
+        if (false === ($buf = socket_read($msgsock, 2048, PHP_NORMAL_READ))) {
+            echo "socket_read() fallita: motivo: " . socket_strerror(socket_last_error($msgsock)) . "\n";
+            break 2;
+        }
+        if (!$buf = trim($buf)) {
+            continue;
+        }
+        if ($buf == 'quit') {
+            break;
+        }
+        if ($buf == 'shutdown') {
+            socket_close($msgsock);
+            break 2;
+        }
+        $talkback = "PHP: Hai detto '$buf'.\n";
+        socket_write($msgsock, $talkback, strlen($talkback));
+        echo "$buf\n";
+    } while (true);
+    socket_close($msgsock);
+} while (true);
+
+socket_close($sock);
+?>
+]]>
+   </programlisting>
+  </example>
+ </para>
+ <para>
+  <example>
+   <title>Esempio di socket: semplice client TCP/IP</title>
+   <para>
+    Questo esempio mostra un semplice client HTTP monouso. Si limita a
+    connettersi a una pagina, inviare una richiesta HEAD, mostrare la
+    risposta e terminare.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+error_reporting(E_ALL);
+
+echo "<h2>Connessione TCP/IP</h2>\n";
+
+/* Ottiene la porta per il servizio WWW. */
+$service_port = getservbyname('www', 'tcp');
+
+/* Ottiene l'indirizzo IP dell'host di destinazione. */
+$address = gethostbyname('www.example.com');
+
+/* Crea un socket TCP/IP. */
+$socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+if ($socket === false) {
+    echo "socket_create() fallita: motivo: " . socket_strerror(socket_last_error()) . "\n";
+} else {
+    echo "OK.\n";
+}
+
+echo "Tentativo di connessione a '$address' sulla porta '$service_port'...";
+$result = socket_connect($socket, $address, $service_port);
+if ($result === false) {
+    echo "socket_connect() fallita.\nMotivo: ($result) " . socket_strerror(socket_last_error($socket)) . "\n";
+} else {
+    echo "OK.\n";
+}
+
+$in = "HEAD / HTTP/1.1\r\n";
+$in .= "Host: www.example.com\r\n";
+$in .= "Connection: Close\r\n\r\n";
+$out = '';
+
+echo "Invio della richiesta HTTP HEAD...";
+socket_write($socket, $in, strlen($in));
+echo "OK.\n";
+
+echo "Lettura della risposta:\n\n";
+while ($out = socket_read($socket, 2048)) {
+    echo $out;
+}
+
+echo "Chiusura del socket...";
+socket_close($socket);
+echo "OK.\n\n";
+?>
+]]>
+   </programlisting>
+  </example>
+ </para>
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/functions/socket-addrinfo-bind.xml
+++ b/reference/sockets/functions/socket-addrinfo-bind.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 14dc7c47365f2b71f6c907a5ba5bccf42534d5a9 Maintainer: vpinti Status: ready -->
+<refentry xml:id="function.socket-addrinfo-bind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>socket_addrinfo_bind</refname>
+  <refpurpose>Crea un socket a partire da un dato addrinfo ed esegue il bind</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>Socket</type><type>false</type></type><methodname>socket_addrinfo_bind</methodname>
+   <methodparam><type>AddressInfo</type><parameter>address</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Crea un'istanza di <classname>Socket</classname> ed esegue il bind all'<classname>AddressInfo</classname> fornito. Il valore
+   restituito da questa funzione può essere usato con <function>socket_listen</function>.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>address</parameter></term>
+    <listitem>
+     <para>
+      Istanza di <classname>AddressInfo</classname> creata da <function>socket_addrinfo_lookup</function>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Restituisce un'istanza di <classname>Socket</classname> in caso di successo o &false; in caso di fallimento.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       In caso di successo, questa funzione restituisce ora un'istanza di <classname>Socket</classname>;
+       in precedenza veniva restituito un <type>resource</type>.
+      </entry>
+     </row>
+     &sockets.changelog.address-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>socket_addrinfo_connect</function></member>
+    <member><function>socket_addrinfo_explain</function></member>
+    <member><function>socket_addrinfo_lookup</function></member>
+    <member><function>socket_listen</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+ 
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/functions/socket-addrinfo-connect.xml
+++ b/reference/sockets/functions/socket-addrinfo-connect.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7ba008401f4bd7781e49e4d89f7cf0dfbfc01e4f Maintainer: vpinti Status: ready -->
+<refentry xml:id="function.socket-addrinfo-connect" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>socket_addrinfo_connect</refname>
+  <refpurpose>Crea un socket a partire da un dato addrinfo e vi si connette</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>Socket</type><type>false</type></type><methodname>socket_addrinfo_connect</methodname>
+   <methodparam><type>AddressInfo</type><parameter>address</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Crea un'istanza di <classname>Socket</classname> e la connette all'istanza di <classname>AddressInfo</classname> fornita. Il valore
+   restituito da questa funzione può essere usato con le altre funzioni socket.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>address</parameter></term>
+    <listitem>
+     <para>
+      Istanza di <classname>AddressInfo</classname> creata da <function>socket_addrinfo_lookup</function>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Restituisce un'istanza di <classname>Socket</classname> in caso di successo o &false; in caso di fallimento.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       In caso di successo, questa funzione restituisce ora un'istanza di <classname>Socket</classname>;
+       in precedenza veniva restituito un <type>resource</type>.
+      </entry>
+     </row>
+     &sockets.changelog.address-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>socket_addrinfo_bind</function></member>
+    <member><function>socket_addrinfo_explain</function></member>
+    <member><function>socket_addrinfo_lookup</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/functions/socket-addrinfo-explain.xml
+++ b/reference/sockets/functions/socket-addrinfo-explain.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7ba008401f4bd7781e49e4d89f7cf0dfbfc01e4f Maintainer: vpinti Status: ready -->
+<refentry xml:id="function.socket-addrinfo-explain" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>socket_addrinfo_explain</refname>
+  <refpurpose>Ottiene informazioni su addrinfo</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>array</type><methodname>socket_addrinfo_explain</methodname>
+   <methodparam><type>AddressInfo</type><parameter>address</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>socket_addrinfo_explain</function> espone la struttura
+   <literal>addrinfo</literal> sottostante.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>address</parameter></term>
+    <listitem>
+     <para>
+      Istanza di <classname>AddressInfo</classname> creata da <function>socket_addrinfo_lookup</function>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Restituisce un array contenente i campi della struttura <literal>addrinfo</literal>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &sockets.changelog.address-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>socket_addrinfo_bind</function></member>
+    <member><function>socket_addrinfo_connect</function></member>
+    <member><function>socket_addrinfo_lookup</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/functions/socket-addrinfo-lookup.xml
+++ b/reference/sockets/functions/socket-addrinfo-lookup.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: vpinti Status: ready -->
+<refentry xml:id="function.socket-addrinfo-lookup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>socket_addrinfo_lookup</refname>
+  <refpurpose>Ottiene un array con il contenuto di getaddrinfo per l'hostname indicato</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>array</type><type>false</type></type><methodname>socket_addrinfo_lookup</methodname>
+   <methodparam><type>string</type><parameter>host</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>service</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>hints</parameter><initializer>[]</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Ricerca i diversi modi in cui è possibile connettersi a <parameter>host</parameter>. L'array restituito contiene
+   un insieme di istanze di <classname>AddressInfo</classname> a cui è possibile eseguire il bind tramite <function>socket_addrinfo_bind</function>.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>host</parameter></term>
+    <listitem>
+     <para>
+      L'hostname da cercare.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>service</parameter></term>
+    <listitem>
+     <para>
+      Il servizio a cui connettersi. Se il servizio è una stringa numerica, indica la porta.
+      Altrimenti indica il nome di un servizio di rete, che viene mappato a una porta dal sistema operativo.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>hints</parameter></term>
+    <listitem>
+     <para>
+      Gli hint forniscono i criteri per la selezione degli indirizzi restituiti. È possibile specificare gli
+      hint definiti da getaddrinfo.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Restituisce un array di istanze di <classname>AddressInfo</classname> utilizzabili con
+   la famiglia di funzioni <function>socket_addrinfo_<replaceable>*</replaceable></function>.
+   In caso di fallimento, viene restituito &false;.
+  </para>
+ </refsect1>
+ 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Ora lancia un <exceptionname>TypeError</exceptionname> se un qualsiasi valore
+       dell'array <parameter>hints</parameter> non può essere convertito in int, e può
+       lanciare un <exceptionname>ValueError</exceptionname> se uno di questi
+       valori va in overflow.
+      </entry>
+     </row>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       In caso di successo, questa funzione restituisce ora un array di istanze di <classname>AddressInfo</classname>;
+       in precedenza veniva restituito un array di <type>resource</type>.
+      </entry>
+     </row>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       <parameter>service</parameter> ora può essere null.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>socket_addrinfo_bind</function></member>
+    <member><function>socket_addrinfo_connect</function></member>
+    <member><function>socket_addrinfo_explain</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/functions/socket-atmark.xml
+++ b/reference/sockets/functions/socket-atmark.xml
@@ -3,7 +3,7 @@
 <refentry xml:id="function.socket-atmark" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>socket_atmark</refname>
-  <refpurpose>Determina se un socket si trova sulla marca fuori banda</refpurpose>
+  <refpurpose>Determina se un socket si trova in corrispondenza del contrassegno dei dati fuori banda</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,7 +13,7 @@
    <methodparam><type>Socket</type><parameter>socket</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Determina se <parameter>socket</parameter> si trova sulla marca fuori banda.
+   Determina se <parameter>socket</parameter> si trova in corrispondenza del contrassegno dei dati fuori banda.
   </para>
  </refsect1>
 

--- a/reference/sockets/functions/socket-atmark.xml
+++ b/reference/sockets/functions/socket-atmark.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 2c357a0dd6cc195bce10fa974ea14a2e30eb4b5b Maintainer: vpinti Status: ready -->
+<refentry xml:id="function.socket-atmark" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>socket_atmark</refname>
+  <refpurpose>Determina se un socket si trova sulla marca fuori banda</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>socket_atmark</methodname>
+   <methodparam><type>Socket</type><parameter>socket</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Determina se <parameter>socket</parameter> si trova sulla marca fuori banda.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>socket</parameter></term>
+     <listitem>
+      <para>
+       Un'istanza di <classname>Socket</classname> creata con <function>socket_create</function>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Uso di <function>socket_atmark</function> per verificare se il socket è pronto a leggere dati fuori banda.</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$socketServer = socket_create( AF_INET, SOCK_STREAM, SOL_TCP );
+socket_set_option( $socketServer, SOL_SOCKET, SO_REUSEADDR, 1 );
+socket_bind( $socketServer, '127.0.0.1' );
+socket_listen( $socketServer );
+
+$socketClient = socket_create( AF_INET, SOCK_STREAM, SOL_TCP );
+socket_getsockname( $socketServer, $stAddr, $uPort );
+socket_connect( $socketClient, $stAddr, $uPort );
+
+$socket = socket_accept( $socketServer );
+socket_shutdown( $socket, 1 );
+
+$st = 'Questo è un dato normale.';
+socket_send( $socketClient, $st, strlen( $st ), 0 );
+$st = '!'; # TCP consente un solo byte di dati urgenti.
+socket_send( $socketClient, $st, strlen( $st ), MSG_OOB );
+$st = 'Non così urgente.';
+socket_send( $socketClient, $st, strlen( $st ), 0 );
+socket_shutdown( $socketClient );
+
+do {
+    if ( socket_atmark( $socket ) ) {
+        $rc = socket_recv( $socket, $st, 65536, MSG_OOB );
+        echo "Dato urgente ricevuto: ({$rc}) {$st}\n";
+    } else {
+        $rc = socket_recv( $socket, $st, 1024, 0 );
+        echo "Dato normale ricevuto: ({$rc}) {$st}\n";
+    }
+} while ( $rc > 0 );
+socket_close( $socketServer );
+socket_close( $socketClient );
+socket_close( $socket );
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Dato normale ricevuto: (26) Questo è un dato normale.
+Dato urgente ricevuto: (1) !
+Dato normale ricevuto: (18) Non così urgente.
+Dato normale ricevuto: (0)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>socket_connect</function></member>
+    <member><function>socket_create</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/functions/socket-cmsg-space.xml
+++ b/reference/sockets/functions/socket-cmsg-space.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 14dc7c47365f2b71f6c907a5ba5bccf42534d5a9 Maintainer: vpinti Status: ready -->
+<refentry xml:id="function.socket-cmsg-space" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>socket_cmsg_space</refname>
+  <refpurpose>Calcola la dimensione del buffer del messaggio</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>null</type></type><methodname>socket_cmsg_space</methodname>
+   <methodparam><type>int</type><parameter>level</parameter></methodparam>
+   <methodparam><type>int</type><parameter>type</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>num</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Calcola la dimensione del buffer che dovrebbe essere allocato per
+   ricevere i dati ausiliari.
+  </para>
+  &warn.undocumented.func;
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>level</parameter></term>
+     <listitem>
+      <para>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>type</parameter></term>
+     <listitem>
+      <para>
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>socket_recvmsg</function></member>
+    <member><function>socket_sendmsg</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/functions/socket-export-stream.xml
+++ b/reference/sockets/functions/socket-export-stream.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 14dc7c47365f2b71f6c907a5ba5bccf42534d5a9 Maintainer: vpinti Status: ready -->
+<refentry xml:id="function.socket-export-stream" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>socket_export_stream</refname>
+  <refpurpose>Esporta un socket in uno stream che incapsula un socket</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>resource</type><type>false</type></type><methodname>socket_export_stream</methodname>
+   <methodparam><type>Socket</type><parameter>socket</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+
+  </para>
+
+  &warn.undocumented.func;
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>socket</parameter></term>
+    <listitem>
+     <para>
+      
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Restituisce una resource&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &sockets.changelog.socket-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/functions/socket-export-stream.xml
+++ b/reference/sockets/functions/socket-export-stream.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Restituisce una resource&return.falseforfailure;.
+   Restituisce una risorsa&return.falseforfailure;.
   </para>
  </refsect1>
 

--- a/reference/sockets/functions/socket-import-stream.xml
+++ b/reference/sockets/functions/socket-import-stream.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 14dc7c47365f2b71f6c907a5ba5bccf42534d5a9 Maintainer: vpinti Status: ready -->
+<refentry xml:id="function.socket-import-stream" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>socket_import_stream</refname>
+  <refpurpose>Importa uno stream</refpurpose>
+ </refnamediv>
+ 
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>Socket</type><type>false</type></type><methodname>socket_import_stream</methodname>
+   <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Importa uno stream che incapsula un socket in una risorsa dell'estensione socket.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>stream</parameter></term>
+     <listitem>
+      <para>
+       La risorsa dello stream da importare.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Restituisce &false; in caso di fallimento.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       In caso di successo, questa funzione restituisce ora un'istanza di <classname>Socket</classname>;
+       in precedenza veniva restituito un <type>resource</type>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Esempio di <function>socket_import_stream</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$stream = stream_socket_server("udp://0.0.0.0:58380", $errno, $errstr, STREAM_SERVER_BIND); 
+$sock   = socket_import_stream($stream);
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>stream_socket_server</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/functions/socket-set-block.xml
+++ b/reference/sockets/functions/socket-set-block.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 14dc7c47365f2b71f6c907a5ba5bccf42534d5a9 Maintainer: vpinti Status: ready -->
+<refentry xml:id="function.socket-set-block" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>socket_set_block</refname>
+  <refpurpose>Imposta la modalità bloccante su un socket</refpurpose>
+ </refnamediv>
+ 
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>socket_set_block</methodname>
+   <methodparam><type>Socket</type><parameter>socket</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   La funzione <function>socket_set_block</function> rimuove il flag
+   <constant>O_NONBLOCK</constant> sul socket specificato dal parametro
+   <parameter>socket</parameter>.
+  </para>
+  <para>
+   Quando viene eseguita un'operazione (ad es. ricezione, invio, connessione,
+   accettazione, ...) su un socket bloccante, lo script metterà in pausa la
+   propria esecuzione finché non riceve un segnale o non è in grado di eseguire
+   l'operazione.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>socket</parameter></term>
+     <listitem>
+      <para>
+       Un'istanza di <classname>Socket</classname> creata con <function>socket_create</function>
+       o <function>socket_accept</function>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &sockets.changelog.socket-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Esempio di <function>socket_set_block</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$socket = socket_create_listen(1223);
+socket_set_block($socket);
+
+socket_accept($socket);
+?>
+]]>
+    </programlisting>
+    <para>
+     Questo esempio crea un socket in ascolto su tutte le interfacce sulla porta 1223
+     e imposta il socket in modalità <constant>O_BLOCK</constant>.
+     <function>socket_accept</function> rimarrà bloccata finché non ci sarà una
+     connessione da accettare.
+    </para>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>socket_set_nonblock</function></member>
+    <member><function>socket_set_option</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/functions/socket-wsaprotocol-info-export.xml
+++ b/reference/sockets/functions/socket-wsaprotocol-info-export.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 14dc7c47365f2b71f6c907a5ba5bccf42534d5a9 Maintainer: vpinti Status: ready -->
+<refentry xml:id="function.socket-wsaprotocol-info-export" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>socket_wsaprotocol_info_export</refname>
+  <refpurpose>Esporta la struttura WSAPROTOCOL_INFO</refpurpose>
+ </refnamediv>
+ 
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>socket_wsaprotocol_info_export</methodname>
+   <methodparam><type>Socket</type><parameter>socket</parameter></methodparam>
+   <methodparam><type>int</type><parameter>process_id</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Esporta la struttura <literal>WSAPROTOCOL_INFO</literal> nella memoria condivisa e restituisce
+   un identificatore da usare con <function>socket_wsaprotocol_info_import</function>. L'ID
+   esportato è valido solo per il <parameter>process_id</parameter> indicato.
+  </para>
+  <note>
+   <simpara>
+    Questa funzione è disponibile solo su Windows.
+   </simpara>
+  </note>
+ </refsect1>
+ 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>socket</parameter></term>
+    <listitem>
+     <para>
+      Un'istanza di <classname>Socket</classname>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>process_id</parameter></term>
+    <listitem>
+     <para>
+      L'ID del processo che importerà il socket.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+ 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Restituisce un identificatore da usare per l'importazione, &return.falseforfailure;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &sockets.changelog.socket-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>socket_wsaprotocol_info_import</function></member>
+   <member><function>socket_wsaprotocol_info_release</function></member>
+  </simplelist>
+ </refsect1>
+ 
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/functions/socket-wsaprotocol-info-import.xml
+++ b/reference/sockets/functions/socket-wsaprotocol-info-import.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 14dc7c47365f2b71f6c907a5ba5bccf42534d5a9 Maintainer: vpinti Status: ready -->
+<refentry xml:id="function.socket-wsaprotocol-info-import" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>socket_wsaprotocol_info_import</refname>
+  <refpurpose>Importa un Socket da un altro processo</refpurpose>
+ </refnamediv>
+ 
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>Socket</type><type>false</type></type><methodname>socket_wsaprotocol_info_import</methodname>
+   <methodparam><type>string</type><parameter>info_id</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Importa un socket precedentemente esportato da un altro processo.
+  </para>
+  <note>
+   <simpara>
+    Questa funzione è disponibile solo su Windows.
+     </simpara>
+  </note>
+ </refsect1>
+ 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>info_id</parameter></term>
+    <listitem>
+     <para>
+      L'ID che è stato restituito da una precedente chiamata a
+      <function>socket_wsaprotocol_info_export</function>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+ 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Restituisce un'istanza di <classname>Socket</classname> in caso di successo, &return.falseforfailure;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       In caso di successo, questa funzione restituisce ora un'istanza di <classname>Socket</classname>;
+       in precedenza veniva restituito un <type>resource</type>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+ 
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>socket_wsaprotocol_info_export</function></member>
+  </simplelist>
+ </refsect1>
+ 
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/functions/socket-wsaprotocol-info-release.xml
+++ b/reference/sockets/functions/socket-wsaprotocol-info-release.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 6d5949ca08c57e084bd30150ad7a523ecb271af9 Maintainer: vpinti Status: ready -->
+
+<refentry xml:id="function.socket-wsaprotocol-info-release" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>socket_wsaprotocol_info_release</refname>
+  <refpurpose>Rilascia una struttura WSAPROTOCOL_INFO esportata</refpurpose>
+ </refnamediv>
+ 
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>socket_wsaprotocol_info_release</methodname>
+   <methodparam><type>string</type><parameter>info_id</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Rilascia la memoria condivisa corrispondente all'<parameter>info_id</parameter> indicato.
+  </para>
+  <note>
+   <simpara>
+    Questa funzione è disponibile solo su Windows.
+     </simpara>
+  </note>
+ </refsect1>
+ 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>info_id</parameter></term>
+    <listitem>
+     <para>
+      L'ID che è stato restituito da una precedente chiamata a
+      <function>socket_wsaprotocol_info_export</function>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+ 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+ 
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>socket_wsaprotocol_info_export</function></member>
+  </simplelist>
+ </refsect1>
+ 
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/reference.xml
+++ b/reference/sockets/reference.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: af4410a7e15898c3dbe83d6ea38246745ed9c6fb Maintainer: vpinti Status: ready -->
+<reference xml:id="ref.sockets" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>&Functions; dei Socket</title>
+
+ &reference.sockets.entities.functions;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/setup.xml
+++ b/reference/sockets/setup.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 765b2d6eec7dfbaeed900b32aa91a1360d73df42 Maintainer: vpinti Status: ready -->
+
+<chapter xml:id="sockets.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ &reftitle.setup;
+
+ <!-- {{{ Installation -->
+ &reference.sockets.configure;
+ <!-- }}} -->
+
+ <!-- {{{ Resources -->
+ <section xml:id="sockets.resources">
+  &reftitle.resources;
+  <para>
+   Prima di PHP 8.0.0,
+   <function>socket_accept</function>, <function>socket_import_stream</function>,
+   <function>socket_addrinfo_connect</function>, <function>socket_addrinfo_bind</function>,
+   <function>socket_create_listen</function>, <function>socket_wsaprotocol_info_import</function> e
+   <function>socket_create</function> restituivano risorse Socket.
+  </para>
+  <para>
+   Prima di PHP 8.0.0,
+   <function>socket_addrinfo_lookup</function> restituiva un array di risorse AddressInfo.
+  </para>
+ </section>
+ <!-- }}} -->
+
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sockets/socket.xml
+++ b/reference/sockets/socket.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: vpinti Status: ready -->
+<reference xml:id="class.socket" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>La classe Socket</title>
+ <titleabbrev>Socket</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ Socket intro -->
+  <section xml:id="socket.intro">
+   &reftitle.intro;
+   <para>
+    Una classe completamente opaca che, a partire da PHP 8.0.0, sostituisce le risorse <literal>Socket</literal>.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="socket.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>final</modifier>
+     <classname>Socket</classname>
+    </ooclass>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+ <!-- &reference.sockets.entities.socket; -->
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Translates the previously untranslated pages of the sockets extension into Italian.

Section files:
- book.xml, setup.xml, constants.xml (complete), examples.xml, errors.xml, reference.xml
- socket.xml (Socket class), addressinfo.xml (AddressInfo class)
- changelog entities (socket-param, address-param) in language-snippets.ent

Functions:
- socket_set_block, socket_atmark, socket_cmsg_space
- socket_addrinfo_bind / connect / explain / lookup
- socket_export_stream, socket_import_stream
- socket_wsaprotocol_info_export / import / release

All EN-Revision headers are set to the current English revision, maintainer vpinti.

Note: this covers the pages that had no Italian translation yet. The older
sockets pages currently marked EN-Revision: n/a (originally by darvina, last
updated in 2005) are out of date and will be brought up to date in a separate
follow-up PR.

The branch history is intentionally granular — feel free to squash on merge.